### PR TITLE
Added a way to prevent mobs from trampling crops.

### DIFF
--- a/src/main/java/com/markiesch/events/CropTrampleEvent.java
+++ b/src/main/java/com/markiesch/events/CropTrampleEvent.java
@@ -1,0 +1,48 @@
+package com.markiesch.events;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class CropTrampleEvent extends Event implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancelled;
+    private final Entity trampler;
+    private final Block block;
+
+    public CropTrampleEvent(Entity trampler, Block block) {
+        this.trampler = trampler;
+        this.block = block;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    public Entity getTrampler() {
+        return trampler;
+    }
+
+    public Block getBlock() {
+        return block;
+    }
+
+}

--- a/src/main/java/com/markiesch/listeners/CropTrample.java
+++ b/src/main/java/com/markiesch/listeners/CropTrample.java
@@ -1,37 +1,76 @@
 package com.markiesch.listeners;
 
 import com.markiesch.EpicReplant;
+import com.markiesch.events.CropTrampleEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.block.Block;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.EntityInteractEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.plugin.Plugin;
 
 import java.util.List;
 
 public class CropTrample implements Listener {
-    private final Plugin plugin = EpicReplant.getInstance();
-
     @EventHandler (priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerInteractEvent(PlayerInteractEvent event) {
-        if (!event.getAction().equals(Action.PHYSICAL)) return;
+        if (!event.getAction().equals(Action.PHYSICAL)) {
+            return;
+        }
 
-        Block block = event.getClickedBlock();
-        if (block == null) return;
+        CropTrampleEvent cropTrampleEvent = new CropTrampleEvent(event.getPlayer(), event.getClickedBlock());
+        Bukkit.getPluginManager().callEvent(cropTrampleEvent);
+        if (cropTrampleEvent.isCancelled()) {
+            event.setCancelled(true);
+        }
+    }
 
-        Player player = event.getPlayer();
-        if (plugin.getConfig().getBoolean("CropTrampling.requirePermission") && !player.hasPermission("epicreplant.trampling")) return;
+    @EventHandler (priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onEntityTrample(EntityInteractEvent event) {
+        if (event.getEntity() instanceof Player) {
+            return;
+        }
 
-        List<String> disabledWorlds = plugin.getConfig().getStringList("CropTrampling.disabledWorlds");
-        if (disabledWorlds.contains(block.getWorld().getName())) return;
+        CropTrampleEvent cropTrampleEvent = new CropTrampleEvent(event.getEntity(), event.getBlock());
+        Bukkit.getPluginManager().callEvent(cropTrampleEvent);
+        if (cropTrampleEvent.isCancelled()) {
+            event.setCancelled(true);
+        }
+    }
 
-        if (block.getType() != Material.FARMLAND) return;
-        if (plugin.getConfig().getBoolean("CropTrampling.requireBoots")) {
-            if (player.getInventory().getBoots() == null || !player.getInventory().getBoots().getType().equals(Material.LEATHER_BOOTS)) return;
+    @EventHandler (priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onCropTrample(CropTrampleEvent event) {
+        FileConfiguration config = EpicReplant.getInstance().getConfig();
+        List<String> disabledWorlds = config.getStringList("CropTrampling.disabledWorlds");
+        if (disabledWorlds.contains(event.getBlock().getWorld().getName())) {
+            return;
+        }
+
+        if (event.getBlock().getType() != Material.FARMLAND) {
+            return;
+        }
+
+        if (event.getTrampler() instanceof Player) {
+            Player player = ((Player) event.getTrampler());
+
+            if (config.getBoolean("CropTrampling.requirePermission") && !player.hasPermission("epicreplant.trampling")) {
+                return;
+            }
+
+            if (config.getBoolean("CropTrampling.requireBoots")
+                    && (player.getInventory().getBoots() == null || !player.getInventory().getBoots().getType().equals(Material.LEATHER_BOOTS))) {
+                return;
+            }
+            return;
+        }
+
+        List<String> mobs = config.getStringList("CropTrampling.blacklistedMobs");
+        if (mobs.contains(event.getTrampler().getType().toString()) || mobs.contains("*")) {
+            return;
         }
         event.setCancelled(true);
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -37,3 +37,7 @@ CropTrampling:
   disabledWorlds: []
   # Disables/enables the need of leather boots to make the antiCropTrampling work
   requireBoots: true
+  # Mobs in this list are allowed to trample crops. Possible values are found here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/EntityType.html
+  # Adding "*" to this list would allow all mobs to trample crops.
+  blacklistedMobs:
+    - "*"


### PR DESCRIPTION
I also added new event for other plugins to listen to: CropTrampleEvent. This way, it's easier for devs to cancel the event.

Added new config option: CropTrampling.blacklistedMobs. I'm still not sure if this should be a blacklist or a whitelist. I can change it if needed.
